### PR TITLE
Accessibility service will now be highlighted

### DIFF
--- a/app/src/main/java/rk/android/app/privacydashboard/activities/main/MainActivity.java
+++ b/app/src/main/java/rk/android/app/privacydashboard/activities/main/MainActivity.java
@@ -127,7 +127,7 @@ public class MainActivity extends AppCompatActivity {
     private void initOnClickListener(){
 
         binding.buttonAccessSetting.setOnClickListener(view -> {
-            startActivity(new Intent("android.settings.ACCESSIBILITY_SETTINGS"),bundle);
+            Utils.openAccessibilitySettings(this, bundle);
             Toast.makeText(context,getString(R.string.settings_accessibility_on),Toast.LENGTH_SHORT).show();
         });
 

--- a/app/src/main/java/rk/android/app/privacydashboard/util/Utils.java
+++ b/app/src/main/java/rk/android/app/privacydashboard/util/Utils.java
@@ -18,6 +18,7 @@ import android.provider.Settings;
 import android.text.format.DateFormat;
 import android.util.TypedValue;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
@@ -33,6 +34,7 @@ import rk.android.app.privacydashboard.activities.appinfo.AppInfoActivity;
 import rk.android.app.privacydashboard.activities.log.LogsActivity;
 import rk.android.app.privacydashboard.constant.Constants;
 import rk.android.app.privacydashboard.manager.PreferenceManager;
+import rk.android.app.privacydashboard.service.PrivacyService;
 
 public class Utils {
 
@@ -83,6 +85,16 @@ public class Utils {
         Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
         intent.setData(Uri.parse("package:" + packageName));
         context.startActivity(intent, bundle);
+    }
+
+    public static void openAccessibilitySettings(Context context, @Nullable Bundle options) {
+        String appComponentNormalized = new ComponentName(BuildConfig.APPLICATION_ID, PrivacyService.class.getCanonicalName()).flattenToString();
+        Bundle bundle = new Bundle();
+        bundle.putString(":settings:fragment_args_key", appComponentNormalized);
+        Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
+        intent.putExtra(":settings:fragment_args_key", appComponentNormalized);
+        intent.putExtra(":settings:show_fragment_args", bundle);
+        context.startActivity(intent, options);
     }
 
     public static void openLink(Context context, String url) {


### PR DESCRIPTION
When clicking "Open settings" button from the `MainActivity` takes you to Accessibility settings where you need to enable the required service.

This PR will highlight the **Privacy Dashboard** service when Accessibility setting is launched from the app. This is a useful visual information for the user if the service is lost in the pool of other services.

I've attached the recording of the preview!

https://user-images.githubusercontent.com/22119598/143441789-ce6c01e1-0dd3-402b-b83e-54dfac00145c.mp4


